### PR TITLE
Align ascii

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The following extra features have their own requirements:
 For validating Xigt's XML format, I recommend
 [Jing](http://www.thaiopensource.com/relaxng/jing.html).
 
+Depending on the importer, you may need to configure a *config.json* for your particular use case, and point Xigt's import function to it using the built-in commands. Templates for the respective configurations are found within the files in `xigt/importers`.
+
 Note: Xigt is primarily developed and tested on Linux. If you are having
 trouble installing on Windows, Mac, or some other operating system, please
 contact me or file an [issue report](https://github.com/xigt/xigt/issues).
@@ -103,7 +105,7 @@ these features can be ignored for simpler IGT.
 
 ##### Alignment Expressions
 
-[Alignment expressions](https://github.com/xigt/xigt/wiki/Alignment-Expressions) 
+[Alignment expressions](https://github.com/xigt/xigt/wiki/Alignment-Expressions)
 are an expanded referencing system that allow some data to align to more
 than one target, and furthermore allows them to select substrings from
 the target(s).

--- a/xigt/codecs/xigtxml.py
+++ b/xigt/codecs/xigtxml.py
@@ -60,7 +60,7 @@ def loads(s):
     return load(StringIO(s))
 
 
-def dump(f, xc, encoding='utf-8', indent=2):
+def dump(f, xc, encoding='latin-1', indent=2):
     if not isinstance(xc, XigtCorpus):
         raise XigtError(
             'Second argument of dump() must be an instance of XigtCorpus.'

--- a/xigt/importers/toolbox.py
+++ b/xigt/importers/toolbox.py
@@ -98,7 +98,7 @@ default_alignments = {
 default_error_recovery_method = 'ratio'
 
 
-def xigt_import(infile, outfile, options=None):
+def xigt_import(infile, outfile, options=None, encode=None):
 
     if options is None:
         options = {}
@@ -113,11 +113,22 @@ def xigt_import(infile, outfile, options=None):
     # just use existing info to create marker-based alignment info
     options['tb_alignments'] = _make_tb_alignments(options)
 
-    with open(infile, 'r') as in_fh, open(outfile, 'w') as out_fh:
-        tb = toolbox.read_toolbox_file(in_fh)
-        igts = toolbox_igts(tb, options)
-        xc = XigtCorpus(igts=igts, mode='transient')
-        xigtxml.dump(out_fh, xc)
+    # assume 'latin-1' encoding for Toolbox files, otherwise open with specified encoding
+    if encode is None:
+        # read as 'latin-1', write as 'utf-8'
+        with open(infile, 'r', encoding='latin-1') as in_fh, open(outfile, 'w', encoding='utf-8') as out_fh:
+            tb = toolbox.read_toolbox_file(in_fh)
+            igts = toolbox_igts(tb, options)
+            xc = XigtCorpus(igts=igts, mode='transient')
+            xigtxml.dump(out_fh, xc)
+    else:
+        # read as encode, write as 'utf-8'
+        with open(infile, 'r', encoding=encode) as in_fh, open(outfile, 'w', encoding='utf-8') as out_fh:
+            tb = toolbox.read_toolbox_file(in_fh)
+            igts = toolbox_igts(tb, options)
+            xc = XigtCorpus(igts=igts, mode='transient')
+            xigtxml.dump(out_fh, xc)
+
 
 
 def _make_tb_alignments(opts):

--- a/xigt/importers/toolbox.py
+++ b/xigt/importers/toolbox.py
@@ -51,7 +51,7 @@ from xigt.codecs import xigtxml
 from xigt.errors import XigtImportError
 
 try:
-    import toolboxT as toolbox
+    import toolbox
 except ImportError:
     raise ImportError(
         'Could not import Toolbox module. Get it from here:\n'

--- a/xigt/importers/toolbox.py
+++ b/xigt/importers/toolbox.py
@@ -37,6 +37,7 @@
 #   "error_recovery_method": "ratio"
 # }
 
+import codecs
 from collections import OrderedDict
 import logging
 import warnings
@@ -50,7 +51,7 @@ from xigt.codecs import xigtxml
 from xigt.errors import XigtImportError
 
 try:
-    import toolbox
+    import toolboxT as toolbox
 except ImportError:
     raise ImportError(
         'Could not import Toolbox module. Get it from here:\n'
@@ -116,14 +117,14 @@ def xigt_import(infile, outfile, options=None, encode=None):
     # assume 'latin-1' encoding for Toolbox files, otherwise open with specified encoding
     if encode is None:
         # read as 'latin-1', write as 'utf-8'
-        with open(infile, 'r', encoding='latin-1') as in_fh, open(outfile, 'w', encoding='utf-8') as out_fh:
+        with codecs.open(infile, 'r', encoding='latin-1') as in_fh, open(outfile, 'w') as out_fh:
             tb = toolbox.read_toolbox_file(in_fh)
             igts = toolbox_igts(tb, options)
             xc = XigtCorpus(igts=igts, mode='transient')
             xigtxml.dump(out_fh, xc)
     else:
         # read as encode, write as 'utf-8'
-        with open(infile, 'r', encoding=encode) as in_fh, open(outfile, 'w', encoding='utf-8') as out_fh:
+        with codecs.open(infile, 'r', encoding=encode) as in_fh, codecs(outfile, 'w') as out_fh:
             tb = toolbox.read_toolbox_file(in_fh)
             igts = toolbox_igts(tb, options)
             xc = XigtCorpus(igts=igts, mode='transient')


### PR DESCRIPTION
1. Updated `importers/toolbox.py`, using an `encode` argument, to assume the Toolbox text file is encoded as Latin-1. This should be the case for all raw text files directly exported from Toolbox. Assuming a Latin-1 encoding ensures that items with IPA characters, for example, are properly aligned by the importer. The use of an `encode` argument allows for a possible later revision in which the user could specify the encoding of the text file if they wish.

2. Updated `codecs/xigtxml.py` to ensure the `dump` attribute writes an xml file in Latin-1 encoding. This ensures that when the xml file is opened as utf-8 the correct characters are rendered. The `encode` argument could potentially be propagated here to ensure the same encoding is being written to xml as is being read from the original text file.

